### PR TITLE
Add Notes tab with minimal notepad

### DIFF
--- a/boringNotch.xcodeproj/project.pbxproj
+++ b/boringNotch.xcodeproj/project.pbxproj
@@ -81,8 +81,9 @@
 		9A987A0C2C73CA66005CA465 /* DropItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A987A022C73CA66005CA465 /* DropItemView.swift */; };
 		9A987A0D2C73CA66005CA465 /* NotchShelfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A987A032C73CA66005CA465 /* NotchShelfView.swift */; };
 		9A987A102C73CA8D005CA465 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 9A987A0F2C73CA8D005CA465 /* Collections */; };
-		9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */; };
-		B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10348D82C74E56000475897 /* ConditionalModifier.swift */; };
+                9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */; };
+                B1F1F2A52E50C1DA00AA1B2C /* NotesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F1F2A42E50C1D900AA1B2C /* NotesView.swift */; };
+                B10348D92C74E56000475897 /* ConditionalModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10348D82C74E56000475897 /* ConditionalModifier.swift */; };
 		B10A848A2C7BCC940088BFFC /* AirDropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10A84892C7BCC940088BFFC /* AirDropView.swift */; };
 		B10A848C2C7BCD150088BFFC /* AirDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10A848B2C7BCD150088BFFC /* AirDrop.swift */; };
 		B10F84A32C6C9596009F3026 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10F84A22C6C9596009F3026 /* TestView.swift */; };
@@ -209,8 +210,9 @@
 		9A987A012C73CA66005CA465 /* DropItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DropItem.swift; sourceTree = "<group>"; };
 		9A987A022C73CA66005CA465 /* DropItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DropItemView.swift; sourceTree = "<group>"; };
 		9A987A032C73CA66005CA465 /* NotchShelfView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotchShelfView.swift; sourceTree = "<group>"; };
-		9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotchHomeView.swift; sourceTree = "<group>"; };
-		B10348D82C74E56000475897 /* ConditionalModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalModifier.swift; sourceTree = "<group>"; };
+                9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotchHomeView.swift; sourceTree = "<group>"; };
+                B1F1F2A42E50C1D900AA1B2C /* NotesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesView.swift; sourceTree = "<group>"; };
+                B10348D82C74E56000475897 /* ConditionalModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalModifier.swift; sourceTree = "<group>"; };
 		B10A84892C7BCC940088BFFC /* AirDropView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirDropView.swift; sourceTree = "<group>"; };
 		B10A848B2C7BCD150088BFFC /* AirDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirDrop.swift; sourceTree = "<group>"; };
 		B10F84A22C6C9596009F3026 /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
@@ -557,14 +559,15 @@
 		};
 		B186542F2C6F455E000B926A /* Notch */ = {
 			isa = PBXGroup;
-			children = (
-				1160F8D72DD98230006FBB94 /* NotchShape.swift */,
-				9A987A032C73CA66005CA465 /* NotchShelfView.swift */,
-				9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
-				14D570C52C5F38210011E668 /* BoringHeader.swift */,
-				14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */,
-				1471A8582C6281BD0058408D /* BoringNotchWindow.swift */,
-			);
+                        children = (
+                                1160F8D72DD98230006FBB94 /* NotchShape.swift */,
+                                9A987A032C73CA66005CA465 /* NotchShelfView.swift */,
+                                9AB0C6BB2C73C9CB00F7CD30 /* NotchHomeView.swift */,
+                                B1F1F2A42E50C1D900AA1B2C /* NotesView.swift */,
+                                14D570C52C5F38210011E668 /* BoringHeader.swift */,
+                                14D570D12C5F6C6A0011E668 /* BoringExtrasMenu.swift */,
+                                1471A8582C6281BD0058408D /* BoringNotchWindow.swift */,
+                        );
 			path = Notch;
 			sourceTree = "<group>";
 		};
@@ -750,8 +753,9 @@
 				14A7E5882C64A89C008C1BE9 /* HelloAnimation.swift in Sources */,
 				1153BD8F2D986B1F00979FB0 /* MediaControllerProtocol.swift in Sources */,
 				9A987A092C73CA66005CA465 /* Ext+URL.swift in Sources */,
-				9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */,
-				B172AAC02C95DA0B001623F1 /* InlineHUD.swift in Sources */,
+                                9AB0C6BD2C73C9CB00F7CD30 /* NotchHomeView.swift in Sources */,
+                                B1F1F2A52E50C1DA00AA1B2C /* NotesView.swift in Sources */,
+                                B172AAC02C95DA0B001623F1 /* InlineHUD.swift in Sources */,
 				14E9FEAA2C70BF610062E83F /* DownloadView.swift in Sources */,
 				B1B112912C6A572100093D8F /* EditPanelView.swift in Sources */,
 				B1C4489B2C97376A001F0858 /* TipStore.swift in Sources */,

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -283,6 +283,8 @@ struct ContentView: View {
                         NotchHomeView(albumArtNamespace: albumArtNamespace)
                     case .shelf:
                         NotchShelfView()
+                    case .notes:
+                        NotesView()
                     }
                 }
             }

--- a/boringNotch/components/Notch/NotesView.swift
+++ b/boringNotch/components/Notch/NotesView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct NotesView: View {
+    @State private var notesText: String = ""
+
+    private let cornerRadius: CGFloat = 16
+    private let placeholder = "Write a quick note…"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            editor
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(20)
+    }
+
+    private var editor: some View {
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(Color.white.opacity(0.03))
+            )
+            .overlay(alignment: .topLeading) {
+                ZStack(alignment: .topLeading) {
+                    if notesText.isEmpty {
+                        Text(placeholder)
+                            .foregroundStyle(.gray)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 16)
+                    }
+
+                    textEditor
+                }
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var textEditor: some View {
+        TextEditor(text: $notesText)
+            .font(.system(.body, design: .rounded))
+            .foregroundColor(.white)
+            .padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+            .background(Color.clear)
+#if os(macOS)
+            .scrollContentBackground(.hidden)
+#endif
+    }
+}

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -16,7 +16,8 @@ struct TabModel: Identifiable {
 
 let tabs = [
     TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf)
+    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf),
+    TabModel(label: "Notes", icon: "pencil.and.outline", view: .notes)
 ]
 
 struct TabSelectionView: View {

--- a/boringNotch/enums/generic.swift
+++ b/boringNotch/enums/generic.swift
@@ -27,6 +27,7 @@ public enum NotchState {
 public enum NotchViews {
     case home
     case shelf
+    case notes
 }
 
 enum SettingsEnum {


### PR DESCRIPTION
## Summary
- add a new NotesView that presents a rounded text editor with placeholder copy for jotting down quick notes
- register the Notes tab in the Notch view coordination by extending the NotchViews enum, tab selector, and ContentView switch

## Testing
- not run (macOS project, xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc68065134833185f62955c758d72d