### PR TITLE
Simplify app to notes-only experience

### DIFF
--- a/boringNotch/BoringViewCoordinator.swift
+++ b/boringNotch/BoringViewCoordinator.swift
@@ -50,7 +50,8 @@ class BoringViewCoordinator: ObservableObject {
     static let shared = BoringViewCoordinator()
     var notifier: TheBoringWorkerNotifier = .init()
 
-    @Published var currentView: NotchViews = .home
+    @Published var currentView: NotchViews = .notes
+    @Published var notesText: String = ""
     private var sneakPeekDispatch: DispatchWorkItem?
     private var expandingViewDispatch: DispatchWorkItem?
 
@@ -63,9 +64,7 @@ class BoringViewCoordinator: ObservableObject {
         didSet {
             if !alwaysShowTabs {
                 openLastTabByDefault = false
-                if TrayDrop.shared.isEmpty || !Defaults[.openShelfByDefault] {
-                    currentView = .home
-                }
+                currentView = .notes
             }
         }
     }
@@ -232,6 +231,6 @@ class BoringViewCoordinator: ObservableObject {
     }
     
     func showEmpty() {
-        currentView = .home
+        currentView = .notes
     }
 }

--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -6,40 +6,31 @@
 //  Modified by Richard Kunkli on 24/08/2024.
 //
 
-import AVFoundation
-import Combine
 import Defaults
-import KeyboardShortcuts
 import SwiftUI
-import SwiftUIIntrospect
 
 struct ContentView: View {
     @EnvironmentObject var vm: BoringViewModel
-    @ObservedObject var webcamManager = WebcamManager.shared
-
     @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @ObservedObject var musicManager = MusicManager.shared
-    @ObservedObject var batteryModel = BatteryStatusViewModel.shared
 
     @State private var isHovering: Bool = false
     @State private var hoverWorkItem: DispatchWorkItem?
     @State private var debounceWorkItem: DispatchWorkItem?
-
     @State private var isHoverStateChanging: Bool = false
 
     @State private var gestureProgress: CGFloat = .zero
 
     @State private var haptics: Bool = false
 
-    @Namespace var albumArtNamespace
-
-    @Default(.useMusicVisualizer) var useMusicVisualizer
-
-    @Default(.showNotHumanFace) var showNotHumanFace
-    @Default(.useModernCloseAnimation) var useModernCloseAnimation
-
-    private let extendedHoverPadding: CGFloat = 30
     private let zeroHeightHoverPadding: CGFloat = 10
+
+    @Default(.useModernCloseAnimation) var useModernCloseAnimation
+    @Default(.openNotchOnHover) var openNotchOnHover
+    @Default(.enableGestures) var enableGestures
+    @Default(.closeGestureEnabled) var closeGestureEnabled
+    @Default(.enableHaptics) var enableHaptics
+    @Default(.extendHoverArea) var extendHoverArea
+    @Default(.cornerRadiusScaling) var cornerRadiusScaling
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -53,7 +44,7 @@ struct ContentView: View {
                         : cornerRadiusInsets.closed.bottom
                 )
                 .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
-                .background(.black)
+                .background(Color.black)
                 .mask {
                     ((vm.notchState == .open) && Defaults[.cornerRadiusScaling])
                         ? NotchShape(
@@ -78,21 +69,21 @@ struct ContentView: View {
 
             mainLayout
                 .conditionalModifier(!useModernCloseAnimation) { view in
-                    let hoverAnimationAnimation = Animation.bouncy.speed(1.2)
+                    let hoverAnimation = Animation.bouncy.speed(1.2)
                     let notchStateAnimation = Animation.spring.speed(1.2)
                     return
                         view
-                        .animation(hoverAnimationAnimation, value: isHovering)
+                        .animation(hoverAnimation, value: isHovering)
                         .animation(notchStateAnimation, value: vm.notchState)
                         .animation(.smooth, value: gestureProgress)
                         .transition(
                             .blurReplace.animation(.interactiveSpring(dampingFraction: 1.2)))
                 }
                 .conditionalModifier(useModernCloseAnimation) { view in
-                    let hoverAnimationAnimation = Animation.bouncy.speed(1.2)
+                    let hoverAnimation = Animation.bouncy.speed(1.2)
                     let notchStateAnimation = Animation.spring.speed(1.2)
                     return view
-                        .animation(hoverAnimationAnimation, value: isHovering)
+                        .animation(hoverAnimation, value: isHovering)
                         .animation(notchStateAnimation, value: vm.notchState)
                 }
                 .conditionalModifier(Defaults[.openNotchOnHover]) { view in
@@ -111,7 +102,6 @@ struct ContentView: View {
                                 isHovering = hovering
                             }
 
-                            // Only close if mouse leaves and the notch is open
                             if !hovering && vm.notchState == .open {
                                 vm.close()
                             }
@@ -126,7 +116,7 @@ struct ContentView: View {
                                 }
                         }
                 }
-                .conditionalModifier(Defaults[.closeGestureEnabled] && Defaults[.enableGestures]) { view in
+                .conditionalModifier(closeGestureEnabled && enableGestures) { view in
                     view
                         .panGesture(direction: .up) { translation, phase in
                             handleUpGesture(translation: translation, phase: phase)
@@ -155,30 +145,7 @@ struct ContentView: View {
                         }
                     }
                 }
-                .onChange(of: vm.isBatteryPopoverActive) { _, newPopoverState in
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        if !newPopoverState && !isHovering && vm.notchState == .open {
-                            vm.close()
-                        }
-                    }
-                }
                 .sensoryFeedback(.alignment, trigger: haptics)
-                .contextMenu {
-                    Button("Settings") {
-                        SettingsWindowController.shared.showWindow()
-                    }
-                    .keyboardShortcut(KeyEquivalent(","), modifiers: .command)
-//                    Button("Edit") { // Doesnt work....
-//                        let dn = DynamicNotch(content: EditPanelView())
-//                        dn.toggle()
-//                    }
-//                    #if DEBUG
-//                    .disabled(false)
-//                    #else
-//                    .disabled(true)
-//                    #endif
-//                    .keyboardShortcut("E", modifiers: .command)
-                }
         }
         .padding(.bottom, 8)
         .frame(maxWidth: openNotchSize.width, maxHeight: openNotchSize.height, alignment: .top)
@@ -192,7 +159,7 @@ struct ContentView: View {
 
     @ViewBuilder
     func NotchLayout() -> some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading) {
                 if coordinator.firstLaunch {
                     Spacer()
@@ -202,242 +169,28 @@ struct ContentView: View {
                     .padding(.top, 40)
                     Spacer()
                 } else {
-                    if coordinator.expandingView.type == .battery && coordinator.expandingView.show
-                        && vm.notchState == .closed && Defaults[.showPowerStatusNotifications]
-                    {
-                        HStack(spacing: 0) {
-                            HStack {
-                                Text(batteryModel.statusText)
-                                    .font(.subheadline)
-                                    .foregroundStyle(.white)
-                            }
-
-                            Rectangle()
-                                .fill(.black)
-                                .frame(width: vm.closedNotchSize.width + 10)
-
-                            HStack {
-                                BoringBatteryView(
-                                    batteryWidth: 30,
-                                    isCharging: batteryModel.isCharging,
-                                    isInLowPowerMode: batteryModel.isInLowPowerMode,
-                                    isPluggedIn: batteryModel.isPluggedIn,
-                                    levelBattery: batteryModel.levelBattery,
-                                    isForNotification: true
-                                )
-                            }
-                            .frame(width: 76, alignment: .trailing)
-                        }
-                        .frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .center)
-                      } else if coordinator.sneakPeek.show && Defaults[.inlineHUD] && (coordinator.sneakPeek.type != .music) && (coordinator.sneakPeek.type != .battery) {
-                          InlineHUD(type: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, hoverAnimation: $isHovering, gestureProgress: $gestureProgress)
-                              .transition(.opacity)
-                      } else if (!coordinator.expandingView.show || coordinator.expandingView.type == .music) && vm.notchState == .closed && (musicManager.isPlaying || !musicManager.isPlayerIdle) && coordinator.musicLiveActivityEnabled && !vm.hideOnClosed {
-                          MusicLiveActivity()
-                      } else if !coordinator.expandingView.show && vm.notchState == .closed && (!musicManager.isPlaying && musicManager.isPlayerIdle) && Defaults[.showNotHumanFace] && !vm.hideOnClosed  {
-                          BoringFaceAnimation().animation(.interactiveSpring, value: musicManager.isPlayerIdle)
-                      } else if vm.notchState == .open {
-                          BoringHeader()
-                              .frame(height: max(24, vm.effectiveClosedNotchHeight))
-                              .blur(radius: abs(gestureProgress) > 0.3 ? min(abs(gestureProgress), 8) : 0)
-                              .animation(.spring(response: 1, dampingFraction: 1, blendDuration: 0.8), value: vm.notchState)
-                       } else {
-                           Rectangle().fill(.clear).frame(width: vm.closedNotchSize.width - 20, height: vm.effectiveClosedNotchHeight)
-                       }
-
-                      if coordinator.sneakPeek.show {
-                          if (coordinator.sneakPeek.type != .music) && (coordinator.sneakPeek.type != .battery) && !Defaults[.inlineHUD] {
-                              SystemEventIndicatorModifier(eventType: $coordinator.sneakPeek.type, value: $coordinator.sneakPeek.value, icon: $coordinator.sneakPeek.icon, sendEventBack: { _ in
-                                  //
-                              })
-                              .padding(.bottom, 10)
-                              .padding(.leading, 4)
-                              .padding(.trailing, 8)
-                          }
-                          // Old sneak peek music
-                          else if coordinator.sneakPeek.type == .music {
-                              if vm.notchState == .closed && !vm.hideOnClosed && Defaults[.sneakPeekStyles] == .standard {
-                                  HStack(alignment: .center) {
-                                      Image(systemName: "music.note")
-                                      GeometryReader { geo in
-                                          MarqueeText(.constant(musicManager.songTitle + " - " + musicManager.artistName),  textColor: Defaults[.playerColorTinting] ? Color(nsColor: musicManager.avgColor).ensureMinimumBrightness(factor: 0.6) : .gray, minDuration: 1, frameWidth: geo.size.width)
-                                      }
-                                  }
-                                  .foregroundStyle(.gray)
-                                  .padding(.bottom, 10)
-                              }
-                          }
-                      }
-                  }
-              }
-              .conditionalModifier((coordinator.sneakPeek.show && (coordinator.sneakPeek.type == .music) && vm.notchState == .closed && !vm.hideOnClosed && Defaults[.sneakPeekStyles] == .standard) || (coordinator.sneakPeek.show && (coordinator.sneakPeek.type != .music) && (vm.notchState == .closed))) { view in
-                  view
-                      .fixedSize()
-              }
-              .zIndex(2)
-
-            ZStack {
-                if vm.notchState == .open {
-                    switch coordinator.currentView {
-                    case .home:
-                        NotchHomeView(albumArtNamespace: albumArtNamespace)
-                    case .shelf:
-                        NotchShelfView()
-                    case .notes:
-                        NotesView()
-                    }
+                    if vm.notchState == .open {
+                        BoringHeader()
+                            .frame(height: max(24, vm.effectiveClosedNotchHeight))
+                            .blur(radius: abs(gestureProgress) > 0.3 ? min(abs(gestureProgress), 8) : 0)
+                            .animation(.spring(response: 1, dampingFraction: 1, blendDuration: 0.8), value: vm.notchState)
+                     } else {
+                         Rectangle().fill(.clear).frame(width: vm.closedNotchSize.width - 20, height: vm.effectiveClosedNotchHeight)
+                     }
                 }
             }
-            .zIndex(1)
-            .allowsHitTesting(vm.notchState == .open)
-            .blur(radius: abs(gestureProgress) > 0.3 ? min(abs(gestureProgress), 8) : 0)
-            .opacity(abs(gestureProgress) > 0.3 ? min(abs(gestureProgress * 2), 0.8) : 1)
+            .frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .center)
+
+            if vm.notchState == .open {
+                NotesView(text: coordinator.notesText)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
         }
-    }
-
-    @ViewBuilder
-    func BoringFaceAnimation() -> some View {
-        HStack {
-            HStack {
-                Rectangle()
-                    .fill(.clear)
-                    .frame(
-                        width: max(0, vm.effectiveClosedNotchHeight - 12),
-                        height: max(0, vm.effectiveClosedNotchHeight - 12))
-                Rectangle()
-                    .fill(.black)
-                    .frame(width: vm.closedNotchSize.width - 20)
-                MinimalFaceFeatures()
-            }
-        }.frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .center)
-    }
-
-    @ViewBuilder
-    func MusicLiveActivity() -> some View {
-        HStack {
-            HStack {
-                Color.clear
-                    .aspectRatio(1, contentMode: .fit)
-                    .background(
-                        Image(nsImage: musicManager.albumArt)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                    )
-                    .clipped()
-                    .clipShape(
-                        RoundedRectangle(
-                            cornerRadius: MusicPlayerImageSizes.cornerRadiusInset.closed)
-                    )
-                    .matchedGeometryEffect(id: "albumArt", in: albumArtNamespace)
-                    .frame(
-                        width: max(0, vm.effectiveClosedNotchHeight - 12),
-                        height: max(0, vm.effectiveClosedNotchHeight - 12))
-            }
-            .frame(
-                width: max(
-                    0, vm.effectiveClosedNotchHeight - (isHovering ? 0 : 12) + gestureProgress / 2),
-                height: max(0, vm.effectiveClosedNotchHeight - (isHovering ? 0 : 12)))
-
-            Rectangle()
-                .fill(.black)
-                .overlay(
-                    HStack(alignment: .top) {
-                        if coordinator.expandingView.show
-                            && coordinator.expandingView.type == .music
-                        {
-                            MarqueeText(
-                                .constant(musicManager.songTitle),
-                                textColor: Defaults[.coloredSpectrogram]
-                                    ? Color(nsColor: musicManager.avgColor) : Color.gray,
-                                minDuration: 0.4,
-                                frameWidth: 100
-                            )
-                            .opacity(
-                                (coordinator.expandingView.show && Defaults[.enableSneakPeek]
-                                    && Defaults[.sneakPeekStyles] == .inline) ? 1 : 0)
-                            Spacer(minLength: vm.closedNotchSize.width)
-                            // Song Artist
-                            Text(musicManager.artistName)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                                .foregroundStyle(
-                                    Defaults[.coloredSpectrogram]
-                                        ? Color(nsColor: musicManager.avgColor) : Color.gray
-                                )
-                                .opacity(
-                                    (coordinator.expandingView.show
-                                        && coordinator.expandingView.type == .music
-                                        && Defaults[.enableSneakPeek]
-                                        && Defaults[.sneakPeekStyles] == .inline) ? 1 : 0)
-                        }
-                    }
-                )
-                .frame(
-                    width: (coordinator.expandingView.show
-                        && coordinator.expandingView.type == .music && Defaults[.enableSneakPeek]
-                        && Defaults[.sneakPeekStyles] == .inline)
-                        ? 380 : vm.closedNotchSize.width + (isHovering ? 8 : 0))
-
-            HStack {
-                if useMusicVisualizer {
-                    Rectangle()
-                        .fill(
-                            Defaults[.coloredSpectrogram]
-                                ? Color(nsColor: musicManager.avgColor).gradient
-                                : Color.gray.gradient
-                        )
-                        .frame(width: 50, alignment: .center)
-                        .matchedGeometryEffect(id: "spectrum", in: albumArtNamespace)
-                        .mask {
-                            AudioSpectrumView(isPlaying: $musicManager.isPlaying)
-                                .frame(width: 16, height: 12)
-                        }
-                        .frame(
-                            width: max(
-                                0,
-                                vm.effectiveClosedNotchHeight - (isHovering ? 0 : 12)
-                                    + gestureProgress / 2),
-                            height: max(0, vm.effectiveClosedNotchHeight - (isHovering ? 0 : 12)),
-                            alignment: .center)
-                } else {
-                    LottieAnimationView()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
-            }
-            .frame(
-                width: max(
-                    0, vm.effectiveClosedNotchHeight - (isHovering ? 0 : 12) + gestureProgress / 2),
-                height: max(0, vm.effectiveClosedNotchHeight - (isHovering ? 0 : 12)),
-                alignment: .center)
-        }
-        .frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .center)
     }
 
     @ViewBuilder
     var dragDetector: some View {
-        if Defaults[.boringShelf] {
-            Color.clear
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .contentShape(Rectangle())
-                .onDrop(of: [.data], isTargeted: $vm.dragDetectorTargeting) { _ in true }
-                .onChange(of: vm.anyDropZoneTargeting) { _, isTargeted in
-                    if isTargeted, vm.notchState == .closed {
-                        coordinator.currentView = .shelf
-                        doOpen()
-                    } else if !isTargeted {
-                        print("DROP EVENT", vm.dropEvent)
-                        if vm.dropEvent {
-                            vm.dropEvent = false
-                            return
-                        }
-
-                        vm.dropEvent = false
-                        vm.close()
-                    }
-                }
-        } else {
-            EmptyView()
-        }
+        EmptyView()
     }
 
     private func doOpen() {
@@ -562,28 +315,10 @@ struct ContentView: View {
     }
 }
 
-struct FullScreenDropDelegate: DropDelegate {
-    @Binding var isTargeted: Bool
-    let onDrop: () -> Void
-
-    func dropEntered(info _: DropInfo) {
-        isTargeted = true
-    }
-
-    func dropExited(info _: DropInfo) {
-        isTargeted = false
-    }
-
-    func performDrop(info _: DropInfo) -> Bool {
-        isTargeted = false
-        onDrop()
-        return true
-    }
-}
-
 #Preview {
     let vm = BoringViewModel()
     vm.open()
+    BoringViewCoordinator.shared.notesText = "Sample notes"
     return ContentView()
         .environmentObject(vm)
         .frame(width: vm.notchSize.width, height: vm.notchSize.height)

--- a/boringNotch/boringNotchApp.swift
+++ b/boringNotch/boringNotchApp.swift
@@ -5,55 +5,19 @@
 //  Created by Harsh Vardhan  Goswami  on 02/08/24.
 //
 
-import AVFoundation
-import Combine
+import AppKit
 import Defaults
-import KeyboardShortcuts
-import Sparkle
 import SwiftUI
 
 @main
 struct DynamicNotchApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @Default(.menubarIcon) var showMenuBarIcon
-    @Environment(\.openWindow) var openWindow
-
-    let updaterController: SPUStandardUpdaterController
-
-    init() {
-        updaterController = SPUStandardUpdaterController(
-            startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
-
-        // Initialize the settings window controller with the updater controller
-        SettingsWindowController.shared.setUpdaterController(updaterController)
-    }
 
     var body: some Scene {
-        MenuBarExtra("boring.notch", systemImage: "sparkle", isInserted: $showMenuBarIcon) {
-            Button("Settings") {
-                SettingsWindowController.shared.showWindow()
-            }
-            .keyboardShortcut(KeyEquivalent(","), modifiers: .command)
-            CheckForUpdatesView(updater: updaterController.updater)
-            Divider()
-            Button("Restart Boring Notch") {
-                guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return }
-
-                let workspace = NSWorkspace.shared
-
-                if let appURL = workspace.urlForApplication(withBundleIdentifier: bundleIdentifier)
-                {
-
-                    let configuration = NSWorkspace.OpenConfiguration()
-                    configuration.createsNewApplicationInstance = true
-
-                    workspace.openApplication(at: appURL, configuration: configuration)
-                }
-
-                NSApplication.shared.terminate(self)
-            }
+        MenuBarExtra("boring.notch", systemImage: "note.text", isInserted: $showMenuBarIcon) {
             Button("Quit", role: .destructive) {
-                NSApplication.shared.terminate(self)
+                NSApplication.shared.terminate(nil)
             }
             .keyboardShortcut(KeyEquivalent("Q"), modifiers: .command)
         }
@@ -61,62 +25,53 @@ struct DynamicNotchApp: App {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-    var statusItem: NSStatusItem?
-    var windows: [NSScreen: NSWindow] = [:]
-    var viewModels: [NSScreen: BoringViewModel] = [:]
-    var window: NSWindow?
-    let vm: BoringViewModel = .init()
-    @ObservedObject var coordinator = BoringViewCoordinator.shared
-    var whatsNewWindow: NSWindow?
-    var timer: Timer?
-    var closeNotchWorkItem: DispatchWorkItem?
-    private var previousScreens: [NSScreen]?
-    private var onboardingWindowController: NSWindowController?
+    private var window: NSWindow?
+    private let vm: BoringViewModel = .init()
+    private let coordinator = BoringViewCoordinator.shared
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        return false
+        false
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        guard let notes = promptForNotesText() else {
+            NSApplication.shared.terminate(nil)
+            return
+        }
+
+        coordinator.notesText = notes
+        coordinator.currentView = .notes
+
+        setupMainWindow()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        NotificationCenter.default.removeObserver(self)
-        MusicManager.shared.destroy()
-        cleanupWindows()
-    }
-
-    @objc func onScreenLocked(_: Notification) {
-        print("Screen locked")
-        cleanupWindows()
-    }
-
-    @objc func onScreenUnlocked(_: Notification) {
-        print("Screen unlocked")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            self?.cleanupWindows()
-            self?.adjustWindowPosition(changeAlpha: true)
-        }
-    }
-
-    private func cleanupWindows(shouldInvert: Bool = false) {
-        if shouldInvert ? !Defaults[.showOnAllDisplays] : Defaults[.showOnAllDisplays] {
-            for window in windows.values {
-                window.close()
-                NotchSpaceManager.shared.notchSpace.windows.remove(window)
-            }
-            windows.removeAll()
-            viewModels.removeAll()
-        } else if let window = window {
-            window.close()
+        if let window = window {
             NotchSpaceManager.shared.notchSpace.windows.remove(window)
-            self.window = nil
         }
     }
 
-    private func createBoringNotchWindow(for screen: NSScreen, with viewModel: BoringViewModel)
-        -> NSWindow
-    {
+    private func setupMainWindow() {
+        let targetScreen = NSScreen.main ?? NSScreen.screens.first!
+
+        coordinator.selectedScreen = targetScreen.localizedName
+        vm.screen = targetScreen.localizedName
+        vm.notchSize = getClosedNotchSize(screen: targetScreen.localizedName)
+        vm.closedNotchSize = vm.notchSize
+
+        let notchWindow = createBoringNotchWindow(for: targetScreen, with: vm)
+        window = notchWindow
+        positionWindow(notchWindow, on: targetScreen)
+    }
+
+    private func createBoringNotchWindow(for screen: NSScreen, with viewModel: BoringViewModel) -> NSWindow {
         let window = BoringNotchWindow(
             contentRect: NSRect(
-                x: 0, y: 0, width: openNotchSize.width, height: openNotchSize.height),
+                x: 0,
+                y: 0,
+                width: openNotchSize.width,
+                height: openNotchSize.height
+            ),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
             backing: .buffered,
             defer: false
@@ -132,321 +87,54 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return window
     }
 
-    private func positionWindow(_ window: NSWindow, on screen: NSScreen, changeAlpha: Bool = false)
-    {
-        if changeAlpha {
-            window.alphaValue = 0
-        }
-
-        DispatchQueue.main.async { [weak window] in
-            guard let window = window else { return }
-            let screenFrame = screen.frame
-            window.setFrameOrigin(
-                NSPoint(
-                    x: screenFrame.origin.x + (screenFrame.width / 2) - window.frame.width / 2,
-                    y: screenFrame.origin.y + screenFrame.height - window.frame.height
-                ))
-            window.alphaValue = 1
-        }
-    }
-
-    func applicationDidFinishLaunching(_ notification: Notification) {
-
-        coordinator.setupWorkersNotificationObservers()
-
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(screenConfigurationDidChange),
-            name: NSApplication.didChangeScreenParametersNotification,
-            object: nil
+    private func positionWindow(_ window: NSWindow, on screen: NSScreen) {
+        let screenFrame = screen.frame
+        window.setFrameOrigin(
+            NSPoint(
+                x: screenFrame.origin.x + (screenFrame.width / 2) - window.frame.width / 2,
+                y: screenFrame.origin.y + screenFrame.height - window.frame.height
+            )
         )
-
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name.selectedScreenChanged, object: nil, queue: nil
-        ) { [weak self] _ in
-            self?.adjustWindowPosition(changeAlpha: true)
-        }
-
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name.notchHeightChanged, object: nil, queue: nil
-        ) { [weak self] _ in
-            self?.adjustWindowPosition()
-        }
-
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name.automaticallySwitchDisplayChanged, object: nil, queue: nil
-        ) { [weak self] _ in
-            guard let self = self, let window = self.window else { return }
-            window.alphaValue =
-                self.coordinator.selectedScreen == self.coordinator.preferredScreen ? 1 : 0
-        }
-
-        NotificationCenter.default.addObserver(
-            forName: Notification.Name.showOnAllDisplaysChanged, object: nil, queue: nil
-        ) { [weak self] _ in
-            guard let self = self else { return }
-            self.cleanupWindows(shouldInvert: true)
-
-            if !Defaults[.showOnAllDisplays] {
-                let viewModel = self.vm
-                let window = self.createBoringNotchWindow(
-                    for: NSScreen.main ?? NSScreen.screens.first!, with: viewModel)
-                self.window = window
-                self.adjustWindowPosition(changeAlpha: true)
-            } else {
-                self.adjustWindowPosition()
-            }
-        }
-
-        DistributedNotificationCenter.default().addObserver(
-            self, selector: #selector(onScreenLocked(_:)),
-            name: NSNotification.Name(rawValue: "com.apple.screenIsLocked"), object: nil)
-        DistributedNotificationCenter.default().addObserver(
-            self, selector: #selector(onScreenUnlocked(_:)),
-            name: NSNotification.Name(rawValue: "com.apple.screenIsUnlocked"), object: nil)
-
-        KeyboardShortcuts.onKeyDown(for: .toggleSneakPeek) { [weak self] in
-            guard let self = self else { return }
-            self.coordinator.toggleSneakPeek(
-                status: !self.coordinator.sneakPeek.show,
-                type: .music,
-                duration: 3.0
-            )
-        }
-
-        KeyboardShortcuts.onKeyDown(for: .toggleNotchOpen) { [weak self] in
-            guard let self = self else { return }
-
-            let mouseLocation = NSEvent.mouseLocation
-
-            var viewModel = self.vm
-
-            if Defaults[.showOnAllDisplays] {
-                for screen in NSScreen.screens {
-                    if screen.frame.contains(mouseLocation) {
-                        if let screenViewModel = self.viewModels[screen] {
-                            viewModel = screenViewModel
-                            break
-                        }
-                    }
-                }
-            }
-
-            self.closeNotchWorkItem?.cancel()
-            self.closeNotchWorkItem = nil
-
-            switch viewModel.notchState {
-            case .closed:
-                viewModel.open()
-
-                let workItem = DispatchWorkItem { [weak viewModel] in
-                    viewModel?.close()
-                }
-                self.closeNotchWorkItem = workItem
-
-                DispatchQueue.main.asyncAfter(deadline: .now() + 3.0, execute: workItem)
-            case .open:
-                viewModel.close()
-            }
-        }
-
-        if !Defaults[.showOnAllDisplays] {
-            let viewModel = self.vm
-            let window = createBoringNotchWindow(
-                for: NSScreen.main ?? NSScreen.screens.first!, with: viewModel)
-            self.window = window
-            adjustWindowPosition(changeAlpha: true)
-        } else {
-            adjustWindowPosition(changeAlpha: true)
-        }
-
-        if coordinator.firstLaunch {
-            DispatchQueue.main.async {
-                self.showOnboardingWindow()
-            }
-            playWelcomeSound()
-        } else if MusicManager.shared.isNowPlayingDeprecated
-            && Defaults[.mediaController] == .nowPlaying
-        {
-            DispatchQueue.main.async {
-                self.showOnboardingWindow(step: .musicPermission)
-            }
-        }
-
-        previousScreens = NSScreen.screens
     }
 
-    func playWelcomeSound() {
-        let audioPlayer = AudioPlayer()
-        audioPlayer.play(fileName: "boring", fileExtension: "m4a")
-    }
+    private func promptForNotesText() -> String? {
+        let alert = NSAlert()
+        alert.messageText = "Notes"
+        alert.informativeText = "Enter the text to display in the Notes tab."
+        alert.alertStyle = .informational
 
-    func deviceHasNotch() -> Bool {
-        if #available(macOS 12.0, *) {
-            for screen in NSScreen.screens {
-                if screen.safeAreaInsets.top > 0 {
-                    return true
-                }
-            }
-        }
-        return false
-    }
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 320, height: 160))
+        textView.isRichText = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.font = .systemFont(ofSize: NSFont.systemFontSize)
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.drawsBackground = false
+        textView.string = coordinator.notesText
 
-    @objc func screenConfigurationDidChange() {
-        let currentScreens = NSScreen.screens
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 320, height: 160))
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .bezelBorder
+        scrollView.drawsBackground = false
+        scrollView.documentView = textView
 
-        let screensChanged =
-            currentScreens.count != previousScreens?.count
-            || Set(currentScreens.map { $0.localizedName })
-                != Set(previousScreens?.map { $0.localizedName } ?? [])
-            || Set(currentScreens.map { $0.frame }) != Set(previousScreens?.map { $0.frame } ?? [])
+        alert.accessoryView = scrollView
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
 
-        previousScreens = currentScreens
-
-        if screensChanged {
-            DispatchQueue.main.async { [weak self] in
-                self?.cleanupWindows()
-                self?.adjustWindowPosition()
-            }
-        }
-    }
-
-    @objc func adjustWindowPosition(changeAlpha: Bool = false) {
-        if Defaults[.showOnAllDisplays] {
-            let currentScreens = Set(NSScreen.screens)
-
-            for screen in windows.keys where !currentScreens.contains(screen) {
-                if let window = windows[screen] {
-                    window.close()
-                    NotchSpaceManager.shared.notchSpace.windows.remove(window)
-                    windows.removeValue(forKey: screen)
-                    viewModels.removeValue(forKey: screen)
-                }
-            }
-
-            for screen in currentScreens {
-                if windows[screen] == nil {
-                    let viewModel = BoringViewModel(screen: screen.localizedName)
-                    let window = createBoringNotchWindow(for: screen, with: viewModel)
-
-                    windows[screen] = window
-                    viewModels[screen] = viewModel
-                }
-
-                if let window = windows[screen], let viewModel = viewModels[screen] {
-                    positionWindow(window, on: screen, changeAlpha: changeAlpha)
-
-                    if viewModel.notchState == .closed {
-                        viewModel.close()
-                    }
-                }
-            }
-        } else {
-            let selectedScreen: NSScreen
-
-            if let preferredScreen = NSScreen.screens.first(where: {
-                $0.localizedName == coordinator.preferredScreen
-            }) {
-                coordinator.selectedScreen = coordinator.preferredScreen
-                selectedScreen = preferredScreen
-            } else if Defaults[.automaticallySwitchDisplay], let mainScreen = NSScreen.main {
-                coordinator.selectedScreen = mainScreen.localizedName
-                selectedScreen = mainScreen
-            } else {
-                if let window = window {
-                    window.alphaValue = 0
-                }
-                return
-            }
-
-            vm.screen = selectedScreen.localizedName
-            vm.notchSize = getClosedNotchSize(screen: selectedScreen.localizedName)
-
-            if window == nil {
-                window = createBoringNotchWindow(for: selectedScreen, with: vm)
-            }
-
-            if let window = window {
-                positionWindow(window, on: selectedScreen, changeAlpha: changeAlpha)
-
-                if vm.notchState == .closed {
-                    vm.close()
-                }
-            }
-        }
-    }
-
-    @objc func togglePopover(_ sender: Any?) {
-        if window?.isVisible == true {
-            window?.orderOut(nil)
-        } else {
-            window?.orderFrontRegardless()
-        }
-    }
-
-    @objc func showMenu() {
-        statusItem?.menu?.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
-    }
-
-    @objc func quitAction() {
-        NSApplication.shared.terminate(self)
-    }
-
-    private func showOnboardingWindow(step: OnboardingStep = .welcome) {
-        if onboardingWindowController == nil {
-            let window = NSWindow(
-                contentRect: NSRect(x: 0, y: 0, width: 400, height: 600),
-                styleMask: [.titled, .fullSizeContentView],
-                backing: .buffered,
-                defer: false
-            )
-            window.center()
-            window.title = "Onboarding"
-            window.titlebarAppearsTransparent = true
-            window.titleVisibility = .hidden
-            window.contentView = NSHostingView(
-                rootView: OnboardingView(
-                    step: step,
-                    onFinish: {
-                        window.orderOut(nil)
-//                        NSApp.setActivationPolicy(.accessory)
-                        window.close()
-                        NSApp.deactivate()
-                    },
-                    onOpenSettings: {
-                        window.close()
-                        SettingsWindowController.shared.showWindow()
-                    }
-                ))
-            window.isRestorable = false
-            window.identifier = NSUserInterfaceItemIdentifier("OnboardingWindow")
-
-            onboardingWindowController = NSWindowController(window: window)
-        }
-
-//        NSApp.setActivationPolicy(.regular)
+        NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
-        onboardingWindowController?.window?.makeKeyAndOrderFront(nil)
-        onboardingWindowController?.window?.orderFrontRegardless()
-    }
-}
 
-extension Notification.Name {
-    static let selectedScreenChanged = Notification.Name("SelectedScreenChanged")
-    static let notchHeightChanged = Notification.Name("NotchHeightChanged")
-    static let showOnAllDisplaysChanged = Notification.Name("showOnAllDisplaysChanged")
-    static let automaticallySwitchDisplayChanged = Notification.Name("automaticallySwitchDisplayChanged")
-}
+        let response = alert.runModal()
 
-extension CGRect: @retroactive Hashable {
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(origin.x)
-        hasher.combine(origin.y)
-        hasher.combine(size.width)
-        hasher.combine(size.height)
-    }
+        NSApp.setActivationPolicy(.accessory)
 
-    public static func == (lhs: CGRect, rhs: CGRect) -> Bool {
-        return lhs.origin == rhs.origin && lhs.size == rhs.size
+        if response == .alertFirstButtonReturn {
+            return textView.string
+        }
+
+        return nil
     }
 }

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -5,96 +5,25 @@
 //  Created by Harsh Vardhan  Goswami  on 04/08/24.
 //
 
-import Defaults
 import SwiftUI
 
 struct BoringHeader: View {
     @EnvironmentObject var vm: BoringViewModel
-    @ObservedObject var batteryModel = BatteryStatusViewModel.shared
-    @ObservedObject var coordinator = BoringViewCoordinator.shared
-    @StateObject var tvm = TrayDrop.shared
+
     var body: some View {
-        HStack(spacing: 0) {
-            HStack {
-                if (!tvm.isEmpty || coordinator.alwaysShowTabs) && Defaults[.boringShelf] {
-                    TabSelectionView()
-                } else if vm.notchState == .open {
-                    EmptyView()
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .opacity(vm.notchState == .closed ? 0 : 1)
-            .blur(radius: vm.notchState == .closed ? 20 : 0)
-            .animation(.smooth.delay(0.1), value: vm.notchState)
-            .zIndex(2)
+        HStack {
+            Text("Notes")
+                .font(.system(.headline, design: .rounded))
+                .foregroundStyle(.white)
+                .padding(.leading, 12)
 
-            if vm.notchState == .open {
-                Rectangle()
-                    .fill(NSScreen.screens
-                        .first(where: { $0.localizedName == coordinator.selectedScreen })?.safeAreaInsets.top ?? 0 > 0 ? .black : .clear)
-                    .frame(width: vm.closedNotchSize.width)
-                    .mask {
-                        NotchShape()
-                    }
-            }
-
-            HStack(spacing: 4) {
-                if vm.notchState == .open {
-                    if Defaults[.showMirror] {
-                        Button(action: {
-                            vm.toggleCameraPreview()
-                        }) {
-                            Capsule()
-                                .fill(.black)
-                                .frame(width: 30, height: 30)
-                                .overlay {
-                                    Image(systemName: "web.camera")
-                                        .foregroundColor(.white)
-                                        .padding()
-                                        .imageScale(.medium)
-                                }
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                    }
-                    if Defaults[.settingsIconInNotch] {
-                        Button(action: {
-                            SettingsWindowController.shared.showWindow()
-                        }) {
-                            Capsule()
-                                .fill(.black)
-                                .frame(width: 30, height: 30)
-                                .overlay {
-                                    Image(systemName: "gear")
-                                        .foregroundColor(.white)
-                                        .padding()
-                                        .imageScale(.medium)
-                                }
-                        }
-                        .buttonStyle(PlainButtonStyle())
-                    }
-                    if Defaults[.showBatteryIndicator] {
-                        BoringBatteryView(
-                            batteryWidth: 30,
-                            isCharging: batteryModel.isCharging,
-                            isInLowPowerMode: batteryModel.isInLowPowerMode,
-                            isPluggedIn: batteryModel.isPluggedIn,
-                            levelBattery: batteryModel.levelBattery,
-                            maxCapacity: batteryModel.maxCapacity,
-                            timeToFullCharge: batteryModel.timeToFullCharge,
-                            isForNotification: false
-                        )
-                    }
-                }
-            }
-            .font(.system(.headline, design: .rounded))
-            .frame(maxWidth: .infinity, alignment: .trailing)
-            .opacity(vm.notchState == .closed ? 0 : 1)
-            .blur(radius: vm.notchState == .closed ? 20 : 0)
-            .animation(.smooth.delay(0.1), value: vm.notchState)
-            .zIndex(2)
+            Spacer()
         }
-        .foregroundColor(.gray)
-        .environmentObject(vm)
+        .padding(.trailing, 12)
+        .frame(maxWidth: .infinity)
+        .opacity(vm.notchState == .closed ? 0 : 1)
+        .blur(radius: vm.notchState == .closed ? 20 : 0)
+        .animation(.smooth.delay(0.1), value: vm.notchState)
     }
 }
 

--- a/boringNotch/components/Notch/NotesView.swift
+++ b/boringNotch/components/Notch/NotesView.swift
@@ -1,50 +1,50 @@
 import SwiftUI
 
 struct NotesView: View {
-    @State private var notesText: String = ""
+    let text: String
 
     private let cornerRadius: CGFloat = 16
-    private let placeholder = "Write a quick note…"
+    private let placeholder = "No notes provided."
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            editor
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
+                .background(
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .fill(Color.white.opacity(0.03))
+                )
+                .overlay(alignment: .topLeading) {
+                    ScrollView {
+                        content
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                }
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(20)
     }
 
-    private var editor: some View {
-        RoundedRectangle(cornerRadius: cornerRadius)
-            .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
-            .background(
-                RoundedRectangle(cornerRadius: cornerRadius)
-                    .fill(Color.white.opacity(0.03))
-            )
-            .overlay(alignment: .topLeading) {
-                ZStack(alignment: .topLeading) {
-                    if notesText.isEmpty {
-                        Text(placeholder)
-                            .foregroundStyle(.gray)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 16)
-                    }
-
-                    textEditor
-                }
-                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    }
-
-    private var textEditor: some View {
-        TextEditor(text: $notesText)
-            .font(.system(.body, design: .rounded))
-            .foregroundColor(.white)
-            .padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
-            .background(Color.clear)
-#if os(macOS)
-            .scrollContentBackground(.hidden)
-#endif
+    @ViewBuilder
+    private var content: some View {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            Text(placeholder)
+                .font(.system(.body, design: .rounded))
+                .foregroundStyle(.gray)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 16)
+                .padding(.horizontal, 20)
+        } else {
+            Text(text)
+                .font(.system(.body, design: .rounded))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 16)
+                .padding(.horizontal, 20)
+                .textSelection(.enabled)
+        }
     }
 }

--- a/boringNotch/components/Tabs/TabSelectionView.swift
+++ b/boringNotch/components/Tabs/TabSelectionView.swift
@@ -15,8 +15,6 @@ struct TabModel: Identifiable {
 }
 
 let tabs = [
-    TabModel(label: "Home", icon: "house.fill", view: .home),
-    TabModel(label: "Shelf", icon: "tray.fill", view: .shelf),
     TabModel(label: "Notes", icon: "pencil.and.outline", view: .notes)
 ]
 

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -172,9 +172,6 @@ class BoringViewModel: NSObject, ObservableObject {
             self.notchSize = openNotchSize
             self.notchState = .open
         }
-        
-        // Force music information update when notch is opened
-        MusicManager.shared.forceUpdate()
     }
 
     func close() {
@@ -185,13 +182,7 @@ class BoringViewModel: NSObject, ObservableObject {
             self.notchState = .closed
         }
 
-        // Set the current view to shelf if it contains files and the user enables openShelfByDefault
-        // Otherwise, if the user has not enabled openLastShelfByDefault, set the view to home
-        if !TrayDrop.shared.isEmpty && Defaults[.openShelfByDefault] {
-            coordinator.currentView = .shelf
-        } else if !coordinator.openLastTabByDefault {
-            coordinator.currentView = .home
-        }
+        coordinator.currentView = .notes
     }
 
     func closeHello() {


### PR DESCRIPTION
## Summary
- remove legacy tabs, menus, and UI so the notch only renders the notes layout
- prompt for note content on launch and abort start-up when the dialog is cancelled
- render the notes tab as a read-only scrollable view populated with the captured text

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cca05213288331ab3653d594a19b32